### PR TITLE
[DDCI-141] Promote-catalogue

### DIFF
--- a/ckanext/qdes_theme/templates/home/layout1.html
+++ b/ckanext/qdes_theme/templates/home/layout1.html
@@ -1,0 +1,45 @@
+<div role="main">
+  {# set banner_image = h.get_banner_image() #}
+  <div class="main hero" style="{% if banner_image and banner_image.image_url %}background-image: url({{ banner_image.image_url }});{% endif %}">
+    <div class="container">
+      <div class="row row1">
+        <div class="col-md-6 col1">
+          {% block promoted %}
+            {% snippet 'home/snippets/promoted.html' %}
+          {% endblock %}
+        </div>
+        <div class="col-md-6 col2">
+          <div class="box">
+            <section class="module module-narrow module-shallow">
+              <header class="module-heading">
+                <h3 class="media-heading">Total Number of Datasets: {{ h.get_dataset_totals_by_type("dataset") }}</h3>
+              </header>
+            </section>
+            <section class="module module-narrow module-shallow">
+              <header class="module-heading">
+                <h3 class="media-heading">Total Number of Data Services: {{ h.get_dataset_totals_by_type("dataservice") }}</h3>
+              </header>
+            </section>
+          </div>
+          {% block search %}
+            {% snippet 'home/snippets/search.html' %}
+          {% endblock %}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="main">
+    <div class="container">
+      <div class="row row2">
+        <div class="col-md-6 col1">
+            {% set datasets = h.get_most_popular_datasets(5) %}
+            {% snippet 'home/snippets/dataset_list.html', datasets=datasets, header="Most Popular Datasets" %}
+        </div>
+        <div class="col-md-6 col2">
+          {% set datasets = h.get_recently_created_datasets(5) %}
+          {% snippet 'home/snippets/dataset_list.html', datasets=datasets, header="Most Recent Datasets" %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/ckanext/qdes_theme/templates/home/snippets/dataset_list.html
+++ b/ckanext/qdes_theme/templates/home/snippets/dataset_list.html
@@ -1,0 +1,10 @@
+  <div class="box">
+    <section class="module module-narrow module-shallow">
+      <header class="module-heading">
+        <h3 class="media-heading">{{ header }}</h3>
+      </header>
+      {% set list_class = "list-unstyled dataset-list" %}
+      {% set item_class = "dataset-item module-content" %}
+      {% snippet 'snippets/package_list.html', packages=datasets, list_class=list_class, item_class=item_class, truncate=120 %}
+    </section>
+  </div>

--- a/ckanext/qdes_theme/templates/home/snippets/promoted.html
+++ b/ckanext/qdes_theme/templates/home/snippets/promoted.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block home_image_content %}
+  {% set banner_image = h.get_banner_image() %}
+  {% if banner_image and banner_image.image_url %}
+    <a class="media-image" href="#">
+      <img class="img-responsive" src="{{ banner_image.image_url }}" alt="Placeholder" width="420" height="220" />
+    </a>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/qdes_theme/templates/page.html
+++ b/ckanext/qdes_theme/templates/page.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+
+{%- block scripts %}
+  {{ super() }}
+  {% if h.qdes_tracking_enabled() %}
+    {% asset 'base/tracking' %}
+  {% endif %}
+{% endblock -%}


### PR DESCRIPTION
- Added new admin config for 'banner_imageæ
- Added new template overrides:
    - page.html to include tracking js script for ckan.qdes.tracking_enabled
    - layout1.html to override front page layout for:
        - Dataset totals
        - Most popular datasets
        - Most recent datasets created datasets
    - dataset_list.html to list most popular datasets or most recent datasets created datasets
    - promoted.html to include banner image if set in admin config